### PR TITLE
Add "Many" compute environment and job queue

### DIFF
--- a/infrastructure/metaflow-cfn-template.yml
+++ b/infrastructure/metaflow-cfn-template.yml
@@ -39,6 +39,10 @@ Parameters:
       Type: CommaDelimitedList
       Default: "m4.large,m4.xlarge,m4.2xlarge,m4.4xlarge"
       Description: "The instance types for the compute environment as a comma-separated list"
+  ComputeEnvManyInstanceTypes:
+      Type: CommaDelimitedList
+      Default: "m4.large"
+      Description: "The instance types for the compute environment as a comma-separated list"
   ComputeEnvGPUInstanceTypes:
       Type: CommaDelimitedList
       Default: "g4dn.xlarge"
@@ -988,6 +992,25 @@ Resources:
         DesiredvCpus: !Ref DesiredVCPUBatch
         Ec2KeyPair: metaflow-test
       State: ENABLED
+  ComputeEnvironmentMany:
+    Type: AWS::Batch::ComputeEnvironment
+    Properties:
+      Type: MANAGED
+      ServiceRole: !GetAtt 'BatchExecutionRole.Arn'
+      ComputeResources:
+        MaxvCpus: !Ref MaxVCPUBatch
+        SecurityGroupIds:
+          - !GetAtt VPC.DefaultSecurityGroup
+        Type: EC2
+        Subnets:
+          - !Ref Subnet1
+          - !Ref Subnet2
+        MinvCpus: !Ref MinVCPUBatch
+        InstanceRole: !GetAtt 'ECSInstanceProfile.Arn'
+        InstanceTypes: !Ref ComputeEnvManyInstanceTypes
+        DesiredvCpus: !Ref DesiredVCPUBatch
+        Ec2KeyPair: metaflow-test
+      State: ENABLED
   ComputeEnvironmentGPU:
     Type: AWS::Batch::ComputeEnvironment
     Properties:
@@ -1018,6 +1041,16 @@ Resources:
       State: ENABLED
       Priority: 1
       JobQueueName: !Join [ "-", [ 'job-queue-GPU', !Ref 'AWS::StackName' ] ]
+  JobQueueMany:
+    DependsOn: ComputeEnvironment
+    Type: AWS::Batch::JobQueue
+    Properties:
+      ComputeEnvironmentOrder:
+        - Order: 1
+          ComputeEnvironment: !Ref ComputeEnvironmentMany
+      State: ENABLED
+      Priority: 1
+      JobQueueName: !Join [ "-", [ 'job-queue', !Ref 'AWS::StackName' ] ]
   JobQueue:
     DependsOn: ComputeEnvironment
     Type: AWS::Batch::JobQueue

--- a/infrastructure/metaflow-cfn-template.yml
+++ b/infrastructure/metaflow-cfn-template.yml
@@ -1050,7 +1050,7 @@ Resources:
           ComputeEnvironment: !Ref ComputeEnvironmentMany
       State: ENABLED
       Priority: 1
-      JobQueueName: !Join [ "-", [ 'job-queue', !Ref 'AWS::StackName' ] ]
+      JobQueueName: !Join [ "-", [ 'job-queue-many', !Ref 'AWS::StackName' ] ]
   JobQueue:
     DependsOn: ComputeEnvironment
     Type: AWS::Batch::JobQueue

--- a/infrastructure/metaflow-cfn-template.yml
+++ b/infrastructure/metaflow-cfn-template.yml
@@ -998,7 +998,7 @@ Resources:
       Type: MANAGED
       ServiceRole: !GetAtt 'BatchExecutionRole.Arn'
       ComputeResources:
-        MaxvCpus: !Ref MaxVCPUBatch
+        MaxvCpus: 256
         SecurityGroupIds:
           - !GetAtt VPC.DefaultSecurityGroup
         Type: EC2

--- a/research_daps/VERSION
+++ b/research_daps/VERSION
@@ -1,1 +1,1 @@
-20.10.20.3_metaflowconfig
+20.11.17.14_mflow_many_ips


### PR DESCRIPTION
Assures smaller instances are chosen => More IP's per batch job (setting `@batch(cpu=2)` ) will ensure 1 IP per task as long as no EC2 instances are recycled - which generally happens if `max-workers` < the number of tasks

One step towards #14 .